### PR TITLE
Fixed bug where Action succeeds even when the command exits with an error code 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9275,10 +9275,11 @@ function connect(host = 'localhost', username, port = 22, privateKey, password, 
     });
 }
 function executeCommand(ssh, command) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`Executing command: ${command}`);
         try {
-            yield ssh.exec(command, [], {
+            const { code } = yield ssh.exec(command, [], {
                 stream: "both",
                 onStdout(chunk) {
                     console.log(chunk.toString("utf8"));
@@ -9287,10 +9288,13 @@ function executeCommand(ssh, command) {
                     console.log(chunk.toString("utf8"));
                 }
             });
+            if (code > 0) {
+                throw Error(`Command exited with code ${code}`);
+            }
             console.log("✅ SSH Action finished.");
         }
         catch (err) {
-            console.error(`⚠️ An error happened executing command ${command}.`, err);
+            console.error(`⚠️ An error happened executing command ${command}.`, (_a = err === null || err === void 0 ? void 0 : err.message) !== null && _a !== void 0 ? _a : err);
             core.setFailed(err.message);
             process.abort();
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,10 +67,11 @@ function connect(host = 'localhost', username, port = 22, privateKey, password, 
     });
 }
 function executeCommand(ssh, command) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         console.log(`Executing command: ${command}`);
         try {
-            yield ssh.exec(command, [], {
+            const { code } = yield ssh.exec(command, [], {
                 stream: "both",
                 onStdout(chunk) {
                     console.log(chunk.toString("utf8"));
@@ -79,10 +80,13 @@ function executeCommand(ssh, command) {
                     console.log(chunk.toString("utf8"));
                 }
             });
+            if (code > 0) {
+                throw Error(`Command exited with code ${code}`);
+            }
             console.log("✅ SSH Action finished.");
         }
         catch (err) {
-            console.error(`⚠️ An error happened executing command ${command}.`, err);
+            console.error(`⚠️ An error happened executing command ${command}.`, (_a = err === null || err === void 0 ? void 0 : err.message) !== null && _a !== void 0 ? _a : err);
             core.setFailed(err.message);
             process.abort();
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,8 @@ async function executeCommand(ssh: node_ssh, command: string) {
   console.log(`Executing command: ${command}`);
 
   try {
-    await ssh.exec(command, [], {
-      stream: "both",
+    const {code} = await ssh.exec(command, [], {
+      stream: 'both',
       onStdout(chunk) {
         console.log(chunk.toString("utf8"));
       },
@@ -77,9 +77,12 @@ async function executeCommand(ssh: node_ssh, command: string) {
       }
     });
 
+    if (code > 0) {
+      throw Error(`Command exited with code ${code}`);
+    }
     console.log("✅ SSH Action finished.");
   } catch (err) {
-    console.error(`⚠️ An error happened executing command ${command}.`, err);
+    console.error(`⚠️ An error happened executing command ${command}.`, err?.message ?? err);
     core.setFailed(err.message);
     process.abort();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ async function executeCommand(ssh: node_ssh, command: string) {
 
   try {
     const {code} = await ssh.exec(command, [], {
-      stream: 'both',
+      stream: "both",
       onStdout(chunk) {
         console.log(chunk.toString("utf8"));
       },


### PR DESCRIPTION
Fixes [issue#8](https://github.com/garygrossgarten/github-action-ssh/issues/8)

node-ssh uses ssh2 which on using `ssh.exec` returns `SSHExecCommandResponse`:
```typescript
interface SSHExecCommandResponse {
    stdout: string;
    stderr: string;
    code: number | null;
    signal: string | null;
}
```
instead of failing a promise. 


Please merge this PR ASAP.