### PR TITLE
Update action to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: "Try keyboard-interactive user authentication if primary user authentication method fails."
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   color: "purple"


### PR DESCRIPTION
GitHub deprecates Node 12 and actions with [github-action-ssh](https://github.com/garygrossgarten/github-action-ssh) started to fail.